### PR TITLE
Disable horizontal scrolling

### DIFF
--- a/css/larq-f1a6a8.webflow.css
+++ b/css/larq-f1a6a8.webflow.css
@@ -4,6 +4,7 @@ body {
   font-size: 20px;
   line-height: 1.75;
   font-weight: 400;
+  overflow-x: hidden;
 }
 
 h1 {


### PR DESCRIPTION
Previously the website slightly scrolled horizontally due to the hero video extending beyond the boundaries of the page. This PR disables horizontal scrolling since the page will correctly reflows when the width changes.